### PR TITLE
AfterHit effects should activate even if the source faints

### DIFF
--- a/data/mods/champions/scripts.ts
+++ b/data/mods/champions/scripts.ts
@@ -121,4 +121,114 @@ export const Scripts: ModdedBattleScriptsData = {
 			return hasValidMove ? moves : [];
 		},
 	},
+	actions: {
+		// Run `AfterHit` events even if the source fainted
+		spreadMoveHit(targets, pokemon, moveOrMoveName, hitEffect?, isSecondary?, isSelf?) {
+			// Hardcoded for single-target purposes
+			// (no spread moves have any kind of onTryHit handler)
+			const target = targets[0];
+			let damage: (number | boolean | undefined)[] = [];
+			for (const i of targets.keys()) {
+				damage[i] = true;
+			}
+			const move = this.dex.getActiveMove(moveOrMoveName);
+			let hitResult: boolean | number | null = true;
+			let moveData = hitEffect as ActiveMove;
+			if (!moveData) moveData = move;
+			if (!moveData.flags) moveData.flags = {};
+			if (move.target === 'all' && !isSelf) {
+				hitResult = this.battle.singleEvent('TryHitField', moveData, {}, target || null, pokemon, move);
+			} else if ((move.target === 'foeSide' || move.target === 'allySide' || move.target === 'allyTeam') && !isSelf) {
+				hitResult = this.battle.singleEvent('TryHitSide', moveData, {}, target || null, pokemon, move);
+			} else if (target) {
+				hitResult = this.battle.singleEvent('TryHit', moveData, {}, target, pokemon, move);
+			}
+			if (!hitResult) {
+				if (hitResult === false) {
+					this.battle.add('-fail', pokemon);
+					this.battle.attrLastMove('[still]');
+				}
+				return [[false], targets]; // single-target only
+			}
+	
+			// 0. check for substitute
+			if (!isSecondary && !isSelf) {
+				if (move.target !== 'all' && move.target !== 'allyTeam' && move.target !== 'allySide' && move.target !== 'foeSide') {
+					damage = this.tryPrimaryHitEvent(damage, targets, pokemon, move, moveData, isSecondary);
+				}
+			}
+	
+			for (const i of targets.keys()) {
+				if (damage[i] === this.battle.HIT_SUBSTITUTE) {
+					damage[i] = true;
+					targets[i] = null;
+				}
+				if (targets[i] && isSecondary && !moveData.self) {
+					damage[i] = true;
+				}
+				if (!damage[i]) targets[i] = false;
+			}
+			// 1. call to this.battle.getDamage
+			damage = this.getSpreadDamage(damage, targets, pokemon, move, moveData, isSecondary, isSelf);
+	
+			for (const i of targets.keys()) {
+				if (damage[i] === false) targets[i] = false;
+			}
+	
+			// 2. call to this.battle.spreadDamage
+			damage = this.battle.spreadDamage(damage, targets, pokemon, move);
+	
+			for (const i of targets.keys()) {
+				if (damage[i] === false) targets[i] = false;
+			}
+	
+			// 3. onHit event happens here
+			damage = this.runMoveEffects(damage, targets, pokemon, move, moveData, isSecondary, isSelf);
+	
+			for (const i of targets.keys()) {
+				if (!damage[i] && damage[i] !== 0) targets[i] = false;
+			}
+	
+			// steps 4 and 5 can mess with this.battle.activeTarget, which needs to be preserved for Dancer
+			const activeTarget = this.battle.activeTarget;
+	
+			// 4. self drops (start checking for targets[i] === false here)
+			if (moveData.self && !move.selfDropped) this.selfDrops(targets, pokemon, move, moveData, isSecondary);
+	
+			// 5. secondary effects
+			if (moveData.secondaries) this.secondaries(targets, pokemon, move, moveData, isSelf);
+	
+			this.battle.activeTarget = activeTarget;
+	
+			// 6. force switch
+			if (moveData.forceSwitch) damage = this.forceSwitch(damage, targets, pokemon, move);
+	
+			for (const i of targets.keys()) {
+				if (!damage[i] && damage[i] !== 0) targets[i] = false;
+			}
+	
+			const damagedTargets: Pokemon[] = [];
+			const damagedDamage = [];
+			for (const [i, t] of targets.entries()) {
+				if (typeof damage[i] === 'number' && t) {
+					damagedTargets.push(t);
+					damagedDamage.push(damage[i]);
+				}
+			}
+			const pokemonOriginalHP = pokemon.hp;
+			if (damagedDamage.length && !isSecondary && !isSelf) {
+				this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
+				if (moveData.onAfterHit) {
+					for (const t of damagedTargets) {
+						this.battle.singleEvent('AfterHit', moveData, {}, t, pokemon, move);
+					}
+				}
+				if (pokemon.hp && pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {
+					this.battle.runEvent('EmergencyExit', pokemon);
+				}
+			}
+	
+			return [damage, targets];
+		}
+	}
 };

--- a/data/mods/champions/scripts.ts
+++ b/data/mods/champions/scripts.ts
@@ -217,11 +217,16 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			const pokemonOriginalHP = pokemon.hp;
 			if (damagedDamage.length && !isSecondary && !isSelf) {
-				this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
+				if (this.battle.gen >= 5) {
+					this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
+				}
 				if (moveData.onAfterHit) {
 					for (const t of damagedTargets) {
 						this.battle.singleEvent('AfterHit', moveData, {}, t, pokemon, move);
 					}
+				}
+				if (this.battle.gen < 4) {
+					this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
 				}
 				if (pokemon.hp && pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {
 					this.battle.runEvent('EmergencyExit', pokemon);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2224,7 +2224,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		priority: 0,
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
 		onAfterHit(target, source, move) {
-			if (!move.hasSheerForce && source.hp) {
+			if (!move.hasSheerForce) {
 				for (const side of source.side.foeSidesWithConditions()) {
 					side.addSideCondition('spikes');
 				}
@@ -9431,9 +9431,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		priority: 0,
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
 		onAfterHit(target, source) {
-			if (source.hp) {
-				this.field.clearTerrain();
-			}
+			this.field.clearTerrain();
 		},
 		onAfterSubDamage(damage, target, source) {
 			if (source.hp) {
@@ -9982,11 +9980,9 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 			}
 		},
 		onAfterHit(target, source) {
-			if (source.hp) {
-				const item = target.takeItem();
-				if (item) {
-					this.add('-enditem', target, item.name, '[from] move: Knock Off', `[of] ${source}`);
-				}
+			const item = target.takeItem();
+			if (item) {
+				this.add('-enditem', target, item.name, '[from] move: Knock Off', `[of] ${source}`);
 			}
 		},
 		target: "normal",
@@ -12337,16 +12333,16 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
 		onAfterHit(target, pokemon, move) {
 			if (!move.hasSheerForce) {
-				if (pokemon.hp && pokemon.removeVolatile('leechseed')) {
+				if (pokemon.removeVolatile('leechseed')) {
 					this.add('-end', pokemon, 'Leech Seed', '[from] move: Mortal Spin', `[of] ${pokemon}`);
 				}
 				const sideConditions = ['spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge'];
 				for (const condition of sideConditions) {
-					if (pokemon.hp && pokemon.side.removeSideCondition(condition)) {
+					if (pokemon.side.removeSideCondition(condition)) {
 						this.add('-sideend', pokemon.side, this.dex.conditions.get(condition).name, '[from] move: Mortal Spin', `[of] ${pokemon}`);
 					}
 				}
-				if (pokemon.hp && pokemon.volatiles['partiallytrapped']) {
+				if (pokemon.volatiles['partiallytrapped']) {
 					pokemon.removeVolatile('partiallytrapped');
 				}
 			}
@@ -14717,16 +14713,16 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1 },
 		onAfterHit(target, pokemon, move) {
 			if (!move.hasSheerForce) {
-				if (pokemon.hp && pokemon.removeVolatile('leechseed')) {
+				if (pokemon.removeVolatile('leechseed')) {
 					this.add('-end', pokemon, 'Leech Seed', '[from] move: Rapid Spin', `[of] ${pokemon}`);
 				}
 				const sideConditions = ['spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge'];
 				for (const condition of sideConditions) {
-					if (pokemon.hp && pokemon.side.removeSideCondition(condition)) {
+					if (pokemon.side.removeSideCondition(condition)) {
 						this.add('-sideend', pokemon.side, this.dex.conditions.get(condition).name, '[from] move: Rapid Spin', `[of] ${pokemon}`);
 					}
 				}
-				if (pokemon.hp && pokemon.volatiles['partiallytrapped']) {
+				if (pokemon.volatiles['partiallytrapped']) {
 					pokemon.removeVolatile('partiallytrapped');
 				}
 			}
@@ -18100,7 +18096,7 @@ export const Moves: import('../sim/dex-moves').MoveDataTable = {
 		priority: 0,
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
 		onAfterHit(target, source, move) {
-			if (!move.hasSheerForce && source.hp) {
+			if (!move.hasSheerForce) {
 				for (const side of source.side.foeSidesWithConditions()) {
 					side.addSideCondition('stealthrock');
 				}

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1146,7 +1146,7 @@ export class BattleActions {
 					this.battle.singleEvent('AfterHit', moveData, {}, t, pokemon, move);
 				}
 			}
-			if (this.battle.gen < 4) {
+			if (this.battle.gen < 5) {
 				this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
 			}
 			if (pokemon.hp && pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1138,11 +1138,16 @@ export class BattleActions {
 		}
 		const pokemonOriginalHP = pokemon.hp;
 		if (damagedDamage.length && !isSecondary && !isSelf) {
-			this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
-			if (moveData.onAfterHit && (pokemon.hp || this.battle.gen <= 4)) {
+			if (this.battle.gen >= 5) {
+				this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
+			}
+			if (moveData.onAfterHit && pokemon.hp) {
 				for (const t of damagedTargets) {
 					this.battle.singleEvent('AfterHit', moveData, {}, t, pokemon, move);
 				}
+			}
+			if (this.battle.gen < 4) {
+				this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
 			}
 			if (pokemon.hp && pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {
 				this.battle.runEvent('EmergencyExit', pokemon);

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1139,7 +1139,7 @@ export class BattleActions {
 		const pokemonOriginalHP = pokemon.hp;
 		if (damagedDamage.length && !isSecondary && !isSelf) {
 			this.battle.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
-			if (moveData.onAfterHit) {
+			if (moveData.onAfterHit && (pokemon.hp || this.battle.gen <= 4)) {
 				for (const t of damagedTargets) {
 					this.battle.singleEvent('AfterHit', moveData, {}, t, pokemon, move);
 				}


### PR DESCRIPTION
The affected moves are:

- Knock Off, Thief and Covet
- Rapid Spin and Mortal Spin
- Ceaseless Edge and Stone Axe

In Gens 3 and 4, all of these effects trigger even if the Pokémon faints due to Rough Skin (though some were not implemented). In Gens 5+, these effects do not activate if the Pokémon faints due to Rough Skin, Iron Barbs or Rocky Helmet.

Apparently, in Champions, at least Knock Off now removes the opponent's item even if the user faints due to Rocky Helmet: https://www.smogon.com/forums/threads/champions-battle-mechanics-research.3780372/post-10945121

---

Tested on the console and, in Gens 3 and 4, Rapid Spin and Knock Off activate before Rough Skin. That is why the effects activate. I'm sending video proof to Dhelmise showing that Knock Off and Rapid Spin activate before Rough Skin in Gen 4.