### PR TITLE
Implement flag changes

### DIFF
--- a/data/mods/champions/abilities.ts
+++ b/data/mods/champions/abilities.ts
@@ -1,0 +1,6 @@
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
+	unseenfist: {
+		inherit: true,
+		shortDesc: "This Pokemon's contact moves ignore a target's protection and deal 1/4 the usual damage.",
+	},
+};

--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -740,11 +740,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	ragefist: {
 		inherit: true,
 		isNonstandard: "Past",
-	},
-	ragepowder: {
-		inherit: true,
-		flags: { noassist: 1, failcopycat: 1 },
-	},
+},
 	razorleaf: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -740,7 +740,11 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	ragefist: {
 		inherit: true,
 		isNonstandard: "Past",
-},
+	},
+	// ragepowder: {
+	// 	inherit: true,
+	// 	flags: { noassist: 1, failcopycat: 1 },
+	// },
 	razorleaf: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -158,6 +158,10 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		accuracy: 95,
 	},
+	crushclaw: {
+		inherit: true,
+		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
+	},
 	crushgrip: {
 		inherit: true,
 		isNonstandard: "Past",
@@ -221,6 +225,10 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	dragoncheer: {
+		inherit: true,
+		flags: { bypasssub: 1, allyanim: 1, metronome: 1, sound: 1 },
+	},
 	dragonclaw: {
 		inherit: true,
 		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
@@ -262,30 +270,6 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
-	esperwing: {
-		inherit: true,
-		isNonstandard: "Past",
-	},
-	fairywind: {
-		inherit: true,
-		isNonstandard: "Past",
-	},
-	falsesurrender: {
-		inherit: true,
-		isNonstandard: "Past",
-	},
-	falseswipe: {
-		inherit: true,
-		isNonstandard: "Past",
-	},
-	fierywrath: {
-		inherit: true,
-		isNonstandard: "Past",
-	},
-	filletaway: {
-		inherit: true,
-		isNonstandard: "Past",
-	},
 	encore: {
 		inherit: true,
 		condition: {
@@ -317,6 +301,30 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				}
 			},
 		},
+	},
+	esperwing: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
+	fairywind: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
+	falsesurrender: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
+	falseswipe: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
+	fierywrath: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
+	filletaway: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	firelash: {
 		inherit: true,
@@ -501,8 +509,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	kingsshield: {
 		inherit: true,
-		pp: 5,
 		isNonstandard: null,
+		pp: 5,
 	},
 	leafage: {
 		inherit: true,
@@ -564,6 +572,7 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	metalclaw: {
 		inherit: true,
 		isNonstandard: "Past",
+		flags: { contact: 1, protect: 1, mirror: 1, metronome: 1, slicing: 1 },
 	},
 	metronome: {
 		inherit: true,
@@ -726,6 +735,10 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	ragepowder: {
+		inherit: true,
+		flags: { noassist: 1, failcopycat: 1 },
+	},
 	razorleaf: {
 		inherit: true,
 		isNonstandard: "Past",
@@ -858,8 +871,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	snaptrap: {
 		inherit: true,
-		type: "Steel",
 		isNonstandard: null,
+		type: "Steel",
 	},
 	snipeshot: {
 		inherit: true,
@@ -884,8 +897,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	},
 	spinout: {
 		inherit: true,
-		pp: 10,
 		isNonstandard: "Past",
+		pp: 10,
 	},
 	spiritbreak: {
 		inherit: true,

--- a/data/mods/champions/moves.ts
+++ b/data/mods/champions/moves.ts
@@ -196,6 +196,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				target.trySetStatus(status, source);
 			},
 		},
+		desc: "Has a 30% chance to cause the target to either fall asleep, become poisoned, or become paralyzed.",
+		shortDesc: "30% chance to sleep, poison, or paralyze target.",
 	},
 	disarmingvoice: {
 		inherit: true,
@@ -490,6 +492,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 			chance: 20,
 			volatileStatus: 'flinch',
 		},
+		desc: "Has a 20% chance to make the target flinch.",
+		shortDesc: "20% chance to make the target flinch.",
 	},
 	ivycudgel: {
 		inherit: true,
@@ -602,6 +606,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				spa: -1,
 			},
 		},
+		desc: "Has a 10% chance to lower the target's Special Attack by 1 stage.",
+		shortDesc: "10% chance to lower the target's Sp. Atk by 1.",
 	},
 	moongeistbeam: {
 		inherit: true,
@@ -792,6 +798,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 				this.damage(pokemon.baseMaxhp / (pokemon.hasType(['Water', 'Steel']) ? 8 : 16));
 			},
 		},
+		desc: "Causes damage to the target equal to 1/16 of its maximum HP (1/8 if the target is Steel or Water type), rounded down, at the end of each turn during effect. This effect ends when the target is no longer active.",
+		shortDesc: "Deals 1/16 max HP each turn; 1/8 on Steel, Water.",
 	},
 	sandattack: {
 		inherit: true,
@@ -1021,6 +1029,8 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		boosts: {
 			spe: -2,
 		},
+		desc: "Lowers the target's Speed by 2 stages and poisons it.",
+		shortDesc: "Lowers the target's Speed by 2 and poisons it.",
 	},
 	trickortreat: {
 		inherit: true,

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -686,6 +686,19 @@ export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 		inherit: true,
 		priority: 3,
 		flags: { noassist: 1, failcopycat: 1 },
+		condition: {
+			inherit: true,
+			onFoeRedirectTarget(target, source, source2, move) {
+				const ragePowderUser = this.effectState.target;
+				if (ragePowderUser.isSkyDropped()) return;
+
+				if (this.validTarget(ragePowderUser, source, move.target)) {
+					if (move.smartTarget) move.smartTarget = false;
+					this.debug("Rage Powder redirected target of move");
+					return ragePowderUser;
+				}
+			},
+		},
 	},
 	reflect: {
 		inherit: true,

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -1250,8 +1250,7 @@ export const AbilitiesText: { [id: IDEntry]: AbilityText } = {
 	},
 	piercingdrill: {
 		name: "Piercing Drill",
-		desc: "", // TODO
-		shortDesc: "", // TODO
+		shortDesc: "This Pokemon's contact moves ignore a target's protection and deal 1/4 the usual damage.",
 	},
 	pixilate: {
 		name: "Pixilate",
@@ -1771,8 +1770,7 @@ export const AbilitiesText: { [id: IDEntry]: AbilityText } = {
 	},
 	spicyspray: {
 		name: "Spicy Spray",
-		desc: "", // TODO
-		shortDesc: "", // TODO
+		shortDesc: "If this Pokemon is hit by an attack, the attacker becomes burned.",
 	},
 	stakeout: {
 		name: "Stakeout",


### PR DESCRIPTION
I would wait for Psychic Noise and Triage mechanics before removing the Healing flag.

Moves that got the Sound flag:

- Dragon Cheer

Moves that got the Slicing flag:

- Crush Claw
- Dire Claw
- Dragon Claw
- Metal Claw
- Shadow Claw

Moves that lost the Powder flag:

- Rage Powder

Moves that lost the Healing flag:

- Absorb
- Bitter Blade
- Bouncy Bubble
- Draining Kiss
- Drain Punch
- Dream Eater
- Floral Healing
- Giga Drain
- Healing Wish
- Heal Order
- Heal Pulse
- Horn Leech
- Leech Life
- Lunar Dance
- Matcha Gotcha
- Mega Drain
- Oblivion Wing
- Parabolic Charge
- Purify
- Revival Blessing
- Strength Sap