### PR TITLE
Activate White Herb after choosing the Parting Shot switch

### DIFF
--- a/data/mods/champions/items.ts
+++ b/data/mods/champions/items.ts
@@ -1006,6 +1006,7 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	whiteherb: {
 		inherit: true,
 		onAnyAfterMove() {
+			// Desync: proceed from Parting Shot's point of view
 			this.queue.insertChoice({
 				choice: 'event',
 				event: 'WhiteHerb',

--- a/data/mods/champions/items.ts
+++ b/data/mods/champions/items.ts
@@ -1003,6 +1003,20 @@ export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	whiteherb: {
+		inherit: true,
+		onAnyAfterMove() {
+			this.queue.insertChoice({
+				choice: 'event',
+				event: 'WhiteHerb',
+				order: 99, // before switches
+				pokemon: this.effectState.target,
+			});
+		},
+		onWhiteHerb(pokemon) {
+			((this.effect as any).onStart as (p: Pokemon) => void).call(this, this.effectState.target);
+		},
+	},
 	widelens: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -16,6 +16,7 @@ export interface ItemData extends Partial<Item>, PokemonEventMethods {
 export type ModdedItemData = ItemData | Partial<Omit<ItemData, 'name'>> & {
 	inherit: true,
 	onCustap?: (this: Battle, pokemon: Pokemon) => void,
+	onWhiteHerb?: (this: Battle, pokemon: Pokemon) => void,
 	condition?: ModdedConditionData,
 };
 


### PR DESCRIPTION
Intimidate activates after White Herb.
```
|start
|switch|p1a: Torracat|Torracat, M|271/271
|switch|p2a: Wynaut|Wynaut, M|331/331
|turn|1
|
|t:|1775822651
|move|p1a: Torracat|Parting Shot|p2a: Wynaut
|-unboost|p2a: Wynaut|atk|1
|-unboost|p2a: Wynaut|spa|1
|
|t:|1775822651
|switch|p1a: Litten|Litten, M|231/231|[from] Parting Shot
|-enditem|p2a: Wynaut|White Herb
|-clearnegativeboost|p2a: Wynaut|[silent]
|-ability|p1a: Litten|Intimidate|boost
|-unboost|p2a: Wynaut|atk|1
|move|p2a: Wynaut|Sleep Talk||[still]
|-fail|p2a: Wynaut
|
|upkeep
|turn|2
```

Test:
```
	it('should activate after Parting Shot drops both stats and after the switch is resolved', () => {
		battle = common.createBattle([[
			{ species: 'torracat', moves: ['partingshot'] },
			{ species: 'litten', ability: 'intimidate', moves: ['sleeptalk'] },
		], [
			{ species: 'wynaut', item: 'whiteherb', moves: ['sleeptalk'] },
		]]);
		battle.makeChoices();
		const wynaut = battle.p2.active[0];
		assert.holdsItem(wynaut);
		assert.statStage(wynaut, 'atk', -1);
		assert.statStage(wynaut, 'spa', -1);

		battle.makeChoices();
		assert.false.holdsItem(wynaut);
		assert.statStage(wynaut, 'atk', -1);
		assert.statStage(wynaut, 'spa', 0);
	});
```